### PR TITLE
Java choice for odo

### DIFF
--- a/documentation/modules/ROOT/pages/inventory-quarkus.adoc
+++ b/documentation/modules/ROOT/pages/inventory-quarkus.adoc
@@ -489,7 +489,7 @@ odo component create --s2i
 |**java**
 
 |Which version of 'java' component type do you wish to create 
-|**latest**
+|**openjdk-11-el7**
 
 |Which input type do you wish to use for the component
 |**binary**


### PR DESCRIPTION
Contentious change this, but if you want inventory base image via odo CLI to match the IDE task version and also the pkill STOP to work in the probe chapter we need to choose a rhel7 base image for Java not the latest, which defaults to ubi8