### PR TITLE
Remove .svc suffix from inventory-mariadb hostname in in the inventor…

### DIFF
--- a/documentation/modules/ROOT/pages/app-config.adoc
+++ b/documentation/modules/ROOT/pages/app-config.adoc
@@ -233,7 +233,7 @@ metadata:
     app.kubernetes.io/instance: inventory
 data:
   application.properties: |-
-    quarkus.datasource.jdbc.url=jdbc:mariadb://inventory-mariadb.svc:3306/inventorydb
+    quarkus.datasource.jdbc.url=jdbc:mariadb://inventory-mariadb:3306/inventorydb
     quarkus.datasource.username=inventory
     quarkus.datasource.password=inventory
 ----


### PR DESCRIPTION
…y configmap

The inventory-mariadb.svc hostname in the configmap is not resolved. Removing the .svc suffix resolves the problem