### PR TITLE
Remove -n in the oc rsh command

### DIFF
--- a/documentation/modules/ROOT/pages/app-config.adoc
+++ b/documentation/modules/ROOT/pages/app-config.adoc
@@ -375,7 +375,7 @@ You can also connect to the Catalog PostgreSQL database and verify that the seed
 
 [source,shell,subs="{markup-in-source}",role=copypaste]
 ----
-oc rsh -n dc/catalog-postgresql
+oc rsh dc/catalog-postgresql
 ----
 
 Once connected to the PostgreSQL container, run the following:


### PR DESCRIPTION
The -n is an invalid flag in the oc rsh command. Removing it resolves the problem.